### PR TITLE
Downsample index

### DIFF
--- a/activities/resolution_hierarchy.py
+++ b/activities/resolution_hierarchy.py
@@ -127,7 +127,7 @@ def downsample_channel(args):
         frame_stop = frame(config['frame_stop_key'])
         step = config['step']
         use_iso_flag = config['iso_flag'] # If the resulting cube should be marked with the ISO flag
-        index_annotations = args['annotation_index_max'] < (args['resolution_max'] - 1)
+        index_annotations = args['resolution'] < (args['annotation_index_max'] - 1)
 
         # Round to the furthest full cube from the center of the data
         cubes_start = frame_start // dim
@@ -139,6 +139,7 @@ def downsample_channel(args):
         log.debug("Cubes corner: {}".format(cubes_start))
         log.debug("Cubes extent: {}".format(cubes_stop))
         log.debug("Downsample step: {}".format(step))
+        log.debug("Indexing Annotations: {}".format(index_annotations))
 
         # Call the downsample_volume lambda to process the data
         fanout(aws.get_session(),

--- a/activities/resolution_hierarchy.py
+++ b/activities/resolution_hierarchy.py
@@ -75,6 +75,9 @@ def downsample_channel(args):
             resolution_max (int) The maximum resolution to generate
             res_lt_max (bool) = args['resolution'] < (args['resolution_max'] - 1)
 
+            annotation_index_max (int) The maximum resolution to index annotation channel cubes at
+                                       When annotation_index_max = N, indices will exist for res 0 - (N - 1)
+
             type (str) 'isotropic' | 'anisotropic'
             iso_resolution (int) if resolution >= iso_resolution && type == 'anisotropic' downsample both
         }
@@ -124,6 +127,7 @@ def downsample_channel(args):
         frame_stop = frame(config['frame_stop_key'])
         step = config['step']
         use_iso_flag = config['iso_flag'] # If the resulting cube should be marked with the ISO flag
+        index_annotations = args['annotation_index_max'] < (args['resolution_max'] - 1)
 
         # Round to the furthest full cube from the center of the data
         cubes_start = frame_start // dim
@@ -139,7 +143,7 @@ def downsample_channel(args):
         # Call the downsample_volume lambda to process the data
         fanout(aws.get_session(),
                args['downsample_volume_sfn'],
-               make_args(args, cubes_start, cubes_stop, step, dim, use_iso_flag),
+               make_args(args, cubes_start, cubes_stop, step, dim, use_iso_flag, index_annotations),
                max_concurrent = MAX_NUM_PROCESSES,
                rampup_delay = RAMPUP_DELAY,
                rampup_backoff = RAMPUP_BACKOFF,
@@ -173,7 +177,7 @@ def downsample_channel(args):
     args['res_lt_max'] = args['resolution'] < (args['resolution_max'] - 1)
     return args
 
-def make_args(args, start, stop, step, dim, use_iso_flag):
+def make_args(args, start, stop, step, dim, use_iso_flag, index_annotations):
     for target in xyz_range(start, stop, step = step):
         yield {
             'lambda-name' : 'downsample_volume', # name of the function in multiLambda to call
@@ -181,6 +185,7 @@ def make_args(args, start, stop, step, dim, use_iso_flag):
             'target': target, # XYZ type is automatically handled by JSON.dumps
             'step': step,     # Since it is a subclass of tuple
             'dim': dim,
-            'use_iso_flag': use_iso_flag
+            'use_iso_flag': use_iso_flag,
+            'index_annotations': index_annotations,
         }
 

--- a/lambda/downsample_volume.py
+++ b/lambda/downsample_volume.py
@@ -286,6 +286,21 @@ def downsample_volume(args, target, step, dim, use_iso_key):
                              '{}&{}&{}&{}'.format(exp_id, chan_id, resolution + 1, ingest_job))
         s3_index.put(idx_key)
 
+    if annotation_chan and False:
+        ids = ndlib.unique(cube)
+
+        # Convert IDs to strings and drop any IDs that equal zero
+        ids = [str(id) for id in ids if id != 0]
+
+        if len(ids) > 0:
+            idx_key = S3IndexKey(obj_key, version)
+            s3_index.update_ids(idx_key, ids)
+
+            for id in ids:
+                idx_key = HashedKey(iso, col_id, exp_id, chan_id, resolution + 1, id)
+                chan_key = IdIndexKey(idx_key, version)
+                id_index.update_id(chan_key, obj_key)
+
 def downsample_cube(volume, cube, is_annotation):
     """Downsample the given Buffer into the target Buffer
 

--- a/lambda/downsample_volume.py
+++ b/lambda/downsample_volume.py
@@ -171,7 +171,7 @@ class DynamoDBTable(object):
 
 #### Main lambda logic ####
 
-def downsample_volume(args, target, step, dim, use_iso_key):
+def downsample_volume(args, target, step, dim, use_iso_key, index_annotations):
     """Downsample a volume into a single cube
 
     Download `step` cubes from S3, downsample them into a single cube, upload
@@ -286,7 +286,7 @@ def downsample_volume(args, target, step, dim, use_iso_key):
                              '{}&{}&{}&{}'.format(exp_id, chan_id, resolution + 1, ingest_job))
         s3_index.put(idx_key)
 
-    if annotation_chan and False:
+    if annotation_chan and index_annotations:
         ids = ndlib.unique(cube)
 
         # Convert IDs to strings and drop any IDs that equal zero
@@ -349,7 +349,7 @@ def handler(args, context):
     convert('step')
     convert('dim')
 
-    downsample_volume(args['args'], args['target'], args['step'], args['dim'], args['use_iso_flag'])
+    downsample_volume(args['args'], args['target'], args['step'], args['dim'], args['use_iso_flag'], args['index_annotations'])
 
 ## Entry point for multiLambda ##
 log.debug("sys.argv[1]: " + sys.argv[1])


### PR DESCRIPTION
Re-add the logic to create the S3 and ID Index entries for annotation channels. Allow the caller to limit the number of levels that index entries will be created for.

Linked to jhuapl-boss/boss/issues/9