### PR TITLE
BOSS Backup and Restore - to integration

### DIFF
--- a/bossutils/configuration.py
+++ b/bossutils/configuration.py
@@ -26,6 +26,9 @@ def download_and_save():
     """Download the boss.config file from User-data and save it to CONFIG_FILE"""
     user_data = utils.read_url(utils.USERDATA_URL)
 
+    if not user_data.strip().startswith('['):
+        raise Exception("User Data is not an INI file")
+
     with open(CONFIG_FILE, "w") as fh:
         fh.write(user_data)
 


### PR DESCRIPTION
Update to the code used by bossutils firstboot script to download the ec2 instance's user data and save it as `/etc/boss/boss.config`. Now it checks to make sure the user data is an INI file before saving it.

This is because for backups bossutils is being installed on an AMI that is launched by Data Pipeline, which doesn't provide the same user data, which caused a problem when scripts tried to create their own boss.config file.