### PR TITLE
Lambdas to clean up ingest tiles.

### DIFF
--- a/lambda/delete_tile_index_entry_lambda.py
+++ b/lambda/delete_tile_index_entry_lambda.py
@@ -1,0 +1,52 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Lambda that removes the entry from the DynamoDB tile index for a given chunk.
+This happens after a chunk is successfully placed in the cuboid bucket as
+Boss cuboids.
+
+Does not handle errors.  Assumed that this lambda will be invoked
+asynchronously and caller will rely on AWS' automatic retries (3).
+
+event: {
+    'chunk_key': (str) key identifying entry in tile index.
+    'task_id': (int) Id of the ingest job that the chunk belongs to.
+    'region': (str) AWS region tile index lives in.
+    'tile_index': (str) Name of the DynamoDB table that is the tile index.
+}
+"""
+
+import boto3
+
+
+def handler(event, context):
+    """
+    Entry point for the lambda function.
+
+    Args:
+        event (dict): Lambda input parameters.  See module level comments.
+        context (dict): Standard lambda context parameter (ignored).
+
+    Raises:
+    """
+    resp = delete_entry(event)
+
+def delete_entry(event):
+    chunk_key = event['chunk_key']
+    task_id = event['task_id']
+    key = {'chunk_key': {'S':chunk_key}, 'task_id': {'N': str(task_id)}}
+
+    dynamo = boto3.client('dynamodb', region_name=event['region'])
+    resp = dynamo.delete_item(Key=key, TableName=event['tile_index'])

--- a/lambda/delete_tile_objs_lambda.py
+++ b/lambda/delete_tile_objs_lambda.py
@@ -1,0 +1,74 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Remove tiles associated with a single chunk from the tile bucket.
+
+Does not handle errors.  Assumed that this lambda will be invoked
+asynchronously and caller will rely on AWS' automatic retries (3).
+
+event: {
+    tile_key_list (list[str]): list of S3 keys to delete from bucket
+    region (str): AWS region bucket lives in
+    bucket (str): Name of tile bucket
+}
+"""
+
+import boto3
+
+
+class DeleteFailed(Exception):
+    """
+    Raised when at least one key passed to delete_objects() failed to delete.
+    """
+    def __init__(self, msg):
+        super().__init__(msg)
+
+def handler(event, context):
+    """
+    Entry point for the lambda function.
+
+    Args:
+        event (dict): Lambda input parameters.  See module level comments.
+        context (dict): Standard lambda context parameter (ignored).
+
+    Raises:
+        (DeleteFailed): Raised when failed to delete at least one key.
+    """
+    resp = delete_keys(event)
+    if 'Errors' in resp:
+        raise DeleteFailed('Error deleting: {}'.format(resp['Errors']))
+
+def delete_keys(event):
+    """
+    Makes S3 API call to delete multiple keys from the given bucket.
+
+    Args:
+        event (dict): Lambda input parameters.  See module level comments.
+
+    Returns:
+        (dict): Response dictionary.
+    """
+    s3 = boto3.client('s3', region_name=event['region'])
+    keys = [{'Key': key} for key in event['tile_key_list']]
+    resp = s3.delete_objects(
+        Bucket=event['bucket'],
+        Delete={
+            'Objects': keys,
+            'Quiet':True
+        }
+    )
+    print(resp)
+
+    return resp

--- a/lambda/tile_upload_lambda.py
+++ b/lambda/tile_upload_lambda.py
@@ -97,6 +97,12 @@ if chunk_ready:
     ingest_queue.sendMessage(json.dumps(metadata))
 
     # Invoke Ingest lambda function
+
+    # While the ingest lambda is still part of the multiLambda, pass the
+    # name here since the ingest lambda won't have access to the normal context
+    # object.  Once ingest is no longer part of the multiLambda, both
+    # 'function-name' and 'lambda-name' may be removed.
+    metadata['function-name'] = metadata["parameters"]["ingest_lambda"]
     metadata["lambda-name"] = "ingest"
     lambda_client = boto3.client('lambda', region_name=SETTINGS.REGION_NAME)
     response = lambda_client.invoke(

--- a/lambdafcns/delete_tile_index_entry_lambda.py
+++ b/lambdafcns/delete_tile_index_entry_lambda.py
@@ -1,0 +1,1 @@
+../lambda/delete_tile_index_entry_lambda.py

--- a/lambdafcns/delete_tile_objs_lambda.py
+++ b/lambdafcns/delete_tile_objs_lambda.py
@@ -1,0 +1,1 @@
+../lambda/delete_tile_objs_lambda.py

--- a/lmbdtest/test_delete_tile_index_entry_lambda.py
+++ b/lmbdtest/test_delete_tile_index_entry_lambda.py
@@ -35,8 +35,10 @@ class TestDeleteTileIndexEntryLambda(unittest.TestCase):
         self.dynamo = boto3.client('dynamodb', region_name=self.region_name)
         self.dynamo.create_table(TableName=self.table_name, **table_params)
 
+
     def tearDown(self):
         self.mock_dynamo.stop()
+
 
     def test_delete(self):
         fake_key = 'fakekey'
@@ -60,7 +62,21 @@ class TestDeleteTileIndexEntryLambda(unittest.TestCase):
 
         handler(event, context)
 
+        resp = self.dynamo.get_item(
+            TableName=self.table_name,
+            Key={
+                'chunk_key': {'S': fake_key},
+                'task_id': {'N': str(task_id)}
+            }
+        )
+
+        self.assertNotIn('Item', resp)
+
+
     def test_delete_key_doesnt_exist(self):
+        """
+        For this test, execution w/o error is passing.
+        """
         fake_key = 'nonexistantkey'
         task_id = 97
 
@@ -73,6 +89,7 @@ class TestDeleteTileIndexEntryLambda(unittest.TestCase):
         context = None
 
         handler(event, context)
+
 
     def get_tile_schema(self):
         """

--- a/lmbdtest/test_delete_tile_index_entry_lambda.py
+++ b/lmbdtest/test_delete_tile_index_entry_lambda.py
@@ -1,0 +1,130 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# lambdafcns is a symbolic link to boss-tools/lambda.  Since lambda is a
+# reserved word, this allows importing lambda functions without
+# updating scripts responsible for deploying the lambda code.
+
+from lambdafcns.delete_tile_index_entry_lambda import handler
+import botocore
+import boto3
+import moto
+import unittest
+from unittest.mock import patch
+
+class TestDeleteTileIndexEntryLambda(unittest.TestCase):
+    def setUp(self):
+        self.table_name = 'test.index.boss'
+        self.region_name = 'us-east-1'
+        table_params = self.get_tile_schema()
+        self.mock_dynamo = moto.mock_dynamodb2()
+        self.mock_dynamo.start()
+
+        self.dynamo = boto3.client('dynamodb', region_name=self.region_name)
+        self.dynamo.create_table(TableName=self.table_name, **table_params)
+
+    def tearDown(self):
+        self.mock_dynamo.stop()
+
+    def test_delete(self):
+        fake_key = 'fakekey'
+        task_id = 47
+
+        event = {
+            'region': self.region_name,
+            'tile_index': self.table_name,
+            'chunk_key': fake_key,
+            'task_id': task_id
+        }
+        context = None
+
+        self.dynamo.put_item(
+            TableName=self.table_name,
+            Item={
+                'chunk_key': {'S': fake_key},
+                'task_id': {'N': str(task_id)}
+            }
+        )
+
+        handler(event, context)
+
+    def test_delete_key_doesnt_exist(self):
+        fake_key = 'nonexistantkey'
+        task_id = 97
+
+        event = {
+            'region': self.region_name,
+            'tile_index': self.table_name,
+            'chunk_key': fake_key,
+            'task_id': task_id
+        }
+        context = None
+
+        handler(event, context)
+
+    def get_tile_schema(self):
+        """
+        Tile index schema from ndingest/nddynamo/schemas/boss_tile_index.json.
+
+        Not loading directly because we don't know where this repo will live
+        on each dev's machine.
+
+        Returns:
+            (dict)
+        """
+        return {
+          "KeySchema": [
+            {
+              "AttributeName": "chunk_key",
+              "KeyType": "HASH"
+            },
+            {
+                "AttributeName": "task_id",
+                "KeyType": "RANGE"
+            }
+          ],
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "chunk_key",
+              "AttributeType": "S"
+            },
+            {
+              "AttributeName": "task_id",
+              "AttributeType": "N"
+            }
+          ],
+          "GlobalSecondaryIndexes": [
+            {
+              "IndexName": "task_index",
+              "KeySchema": [
+                {
+                  "AttributeName": "task_id",
+                  "KeyType": "HASH"
+                }
+              ],
+              "Projection": {
+                "ProjectionType": "ALL"
+              },
+              "ProvisionedThroughput": {
+                "ReadCapacityUnits": 10,
+                "WriteCapacityUnits": 10
+              }
+            }
+          ],
+          "ProvisionedThroughput": {
+            "ReadCapacityUnits": 10,
+            "WriteCapacityUnits": 10
+          }
+        }

--- a/lmbdtest/test_delete_tile_objs_lambda.py
+++ b/lmbdtest/test_delete_tile_objs_lambda.py
@@ -1,0 +1,74 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# lambdafcns is a symbolic link to boss-tools/lambda.  Since lambda is a
+# reserved word, this allows importing lambda functions without
+# updating scripts responsible for deploying the lambda code.
+
+from lambdafcns.delete_tile_objs_lambda import handler, delete_keys, DeleteFailed
+import botocore
+import boto3
+import moto
+import unittest
+from unittest.mock import patch
+
+class TestDeleteTileObjsLambda(unittest.TestCase):
+
+    # moto issue here: https://github.com/spulec/moto/issues/1581
+    @unittest.skip('moto 1.3.3 incorrect reports an error here')
+    @moto.mock_s3
+    def test_delete_non_existent_keys(self):
+        keys = ['foo', 'xyz']
+        event = {
+            'region': 'us-east-1',
+            'bucket': 'test.bucket.boss',
+            'tile_key_list': keys
+        }
+        context = None
+
+        s3 = boto3.resource('s3', region_name=event['region'])
+        s3.create_bucket(Bucket=event['bucket'])
+
+        handler(event, context)
+
+    @moto.mock_s3
+    def test_delete_raises_on_bad_bucket_name(self):
+        keys = ['tile1', 'tile2']
+        event = {
+            'region': 'us-east-1',
+            'bucket': 'bad.bucket.name',
+            'tile_key_list': keys
+        }
+        context = None
+
+        with self.assertRaises(botocore.exceptions.ClientError):
+            handler(event, context)
+
+    @patch('lambdafcns.delete_tile_objs_lambda.delete_keys')
+    def test_delete_raises_on_error_in_resp(self, fake_delete):
+        keys = ['tile1', 'tile2']
+        event = {
+            'region': 'us-east-1',
+            'bucket': 'test.bucket.boss',
+            'tile_key_list': keys
+        }
+        context = None
+
+        fake_delete.return_value = {
+            'Errors': [{'Key': 'tile1'}],
+            'ResponseMetadata': {'HTTPStatusCode': 200}
+        }
+
+        with self.assertRaises(DeleteFailed):
+            handler(event, context)


### PR DESCRIPTION
Two lambdas meant to run asynchronously to delete tiles from S3 tile
bucket and the entries from DynamoDB tile index.

Corrects bug where ingest lambda could timeout while cleaning up, but
there'd be no retry because the ingest message had already been removed
from the queue.

Linked PR: https://github.com/jhuapl-boss/boss-manage/pull/11