### PR TITLE
Vault Token Rotation - to integration

### DIFF
--- a/bossutils/test/test_vault.py
+++ b/bossutils/test/test_vault.py
@@ -32,7 +32,7 @@ class TestVaultClient(unittest.TestCase):
             }
         }
 
-    def test_exceptin_if_cant_auth_to_vault(self, mockClient):
+    def test_exception_if_cant_auth_to_vault(self, mockClient):
         instance = mockClient.return_value
         instance.is_authenticated.return_value = False
         with self.assertRaises(Exception):

--- a/bossutils/vault.py
+++ b/bossutils/vault.py
@@ -35,11 +35,11 @@ def catch_expire(function):
     def wrapper(*args, **kwargs):
         try:
             return function(*args, **kwargs)
-        except: #Need to specify the type of exception...
+        except: #Need to specify the type of exception. 
             blog = BossLogger().logger
             msg = "Your token had expired.  Dynamically creating a new one."
             blog.info(msg)
-            Vault.login()
+            Vault.login(self=None)
             function(*args, **kwargs)
     return wrapper
 

--- a/bossutils/vault.py
+++ b/bossutils/vault.py
@@ -30,13 +30,14 @@ VAULT_URL_KEY = "url"
 VAULT_TOKEN_KEY = "token"
 
 def catch_expire(function):
-        """Catches error raised when token has expired and rotates token if so.
-        Executes the same function once the token has been replaced."""
+    """Catches error raised when token has expired and rotates token if so.
+    Executes the same function once the token has been replaced."""
     def wrapper(*args, **kwargs):
         try:
             return function(*args, **kwargs)
-        except: #Need to specify the type of exception. 
+        except Exception as e:
             blog = BossLogger().logger
+            blog.info(str(e))
             msg = "Your token had expired.  Dynamically creating a new one."
             blog.info(msg)
             Vault.login(self=None)

--- a/bossutils/vault.py
+++ b/bossutils/vault.py
@@ -112,7 +112,7 @@ class Vault:
     def read(self, path, key):
         """Read the specific key from the Vault path.
 
-        An Exception is t:hrown if the path or key do not exist."""
+        An Exception is thrown if the path or key do not exist."""
         response = self.client.read(path)
         if response is not None:
             response = response["data"][key]

--- a/bossutils/vault.py
+++ b/bossutils/vault.py
@@ -22,10 +22,26 @@ VAULT_TOKEN_KEY is the config key for the Vault access token
 import hvac
 from . import configuration
 from . import utils
+import functools
+from bossutils.logger import BossLogger
 
 VAULT_SECTION = "vault"
 VAULT_URL_KEY = "url"
 VAULT_TOKEN_KEY = "token"
+
+def catch_expire(function):
+        """Catches error raised when token has expired and rotates token if so.
+        Executes the same function once the token has been replaced."""
+    def wrapper(*args, **kwargs):
+        try:
+            return function(*args, **kwargs)
+        except:
+            blog = BossLogger().logger
+            msg = "Your token had expired.  Dynamically creating a new one."
+            blog.info(msg)
+            Vault.login()
+            function(*args, **kwargs)
+    return wrapper
 
 class Vault:
     """Vault is a wrapper class for the hvac Vault client that automatically
@@ -50,7 +66,7 @@ class Vault:
         else:
             self.client.token = token
             if not self.client.is_authenticated():
-                raise Exception("Could not authenticate to Vault server")
+                self.login()
 
     def logout(self):
         """Logout and clear the internal state.
@@ -91,6 +107,7 @@ class Vault:
         else:
             return response["data"]
 
+    @catch_expire
     def read(self, path, key):
         """Read the specific key from the Vault path.
 
@@ -103,19 +120,23 @@ class Vault:
             raise Exception("Could not locate {}/{} in Vault".format(path,key))
 
         return response
-
+    
+    @catch_expire
     def write(self, path, **kwargs):
         """Write the given key / values in the given Vault path."""
         self.client.write(path, **kwargs)
 
+    @catch_expire
     def delete(self, path):
         """Delete the given Vault path."""
         self.client.delete(path)
 
+    @catch_expire
     def revoke_secret(self, lease_id):
         """Revoke the given Vault secret."""
         self.client.revoke_secret(lease_id)
 
+    @catch_expire
     def revoke_secret_prefix(self, prefix):
         """Revoke Vault secret(s) starting with the given prefix.
 
@@ -124,6 +145,7 @@ class Vault:
         """
         self.client.revoke_secret_prefix(prefix)
 
+    @catch_expire
     def renew_secret(self, lease_id):
         """Renew the given Vault secret."""
         return self.client.renew_secret(lease_id)

--- a/bossutils/vault.py
+++ b/bossutils/vault.py
@@ -75,19 +75,6 @@ class Vault:
         with open(configuration.CONFIG_FILE, "w") as fh:
             self.config.config.write(fh)
 
-    def rotate_token(self):
-        """Read a new token from the current cubbyhold and override the token
-        stored in the BossConfig."""
-        new_token = self.read("/cubbyhole", "token")
-        self.client.token = new_token
-
-        if not self.client.is_authenticated():
-            raise Exception("Could not authenticate with rotated Vault token")
-
-        self.config[VAULT_SECTION][VAULT_TOKEN_KEY] = new_token
-        with open(configuration.CONFIG_FILE, "w") as fh:
-            self.config.write(fh)
-
     def read_dict(self, path, raw=False):
         """Read a dictionary of keys from the Vault path.
 

--- a/bossutils/vault.py
+++ b/bossutils/vault.py
@@ -35,7 +35,7 @@ def catch_expire(function):
     def wrapper(*args, **kwargs):
         try:
             return function(*args, **kwargs)
-        except Exception as e:
+        except Forbidden as e:
             blog = BossLogger().logger
             blog.info(str(e))
             msg = "Your token had expired.  Dynamically creating a new one."

--- a/bossutils/vault.py
+++ b/bossutils/vault.py
@@ -35,7 +35,7 @@ def catch_expire(function):
     def wrapper(*args, **kwargs):
         try:
             return function(*args, **kwargs)
-        except:
+        except: #Need to specify the type of exception...
             blog = BossLogger().logger
             msg = "Your token had expired.  Dynamically creating a new one."
             blog.info(msg)

--- a/bossutils/vault.py
+++ b/bossutils/vault.py
@@ -41,7 +41,7 @@ def catch_expire(function):
             msg = "Your token had expired.  Dynamically creating a new one."
             blog.info(msg)
             Vault.login(self)
-            function(self, *args, **kwargs)
+            return function(self, *args, **kwargs)
     return wrapper
 
 class Vault:
@@ -112,7 +112,7 @@ class Vault:
     def read(self, path, key):
         """Read the specific key from the Vault path.
 
-        An Exception is thrown is the path or key do not exist."""
+        An Exception is t:hrown if the path or key do not exist."""
         response = self.client.read(path)
         if response is not None:
             response = response["data"][key]

--- a/bossutils/vault.py
+++ b/bossutils/vault.py
@@ -32,16 +32,16 @@ VAULT_TOKEN_KEY = "token"
 def catch_expire(function):
     """Catches error raised when token has expired and rotates token if so.
     Executes the same function once the token has been replaced."""
-    def wrapper(*args, **kwargs):
+    def wrapper(self, *args, **kwargs):
         try:
-            return function(*args, **kwargs)
-        except Forbidden as e:
+            return function(self, *args, **kwargs)
+        except hvac.exceptions.Forbidden as e:
             blog = BossLogger().logger
             blog.info(str(e))
             msg = "Your token had expired.  Dynamically creating a new one."
             blog.info(msg)
-            Vault.login(self=None)
-            function(*args, **kwargs)
+            Vault.login(self)
+            function(self, *args, **kwargs)
     return wrapper
 
 class Vault:


### PR DESCRIPTION
Decorator to catch expiration errors and rotate token. Tested with all current unittest and implemented retry_logic unit test.
Summary:
1. Deleted rotate_token() function
2. login() if the token as expired
3. Decorator function to try running the function and only attempt login() if the token expired
4. test_vault  retry_logic (vault token rotation) unit test
