### PR TITLE
Bug fix for downsampling small frames

### DIFF
--- a/activities/resolution_hierarchy.py
+++ b/activities/resolution_hierarchy.py
@@ -22,7 +22,6 @@ import types
 import json
 import time
 import random
-from math import ceil
 from multiprocessing import Pool, cpu_count
 from datetime import timedelta, datetime
 
@@ -284,8 +283,8 @@ def num_cubes(start, stop, step):
     Return:
         int: The number of volumes in the frame
     """
-    extents = (stop - start) / step
-    return int(ceil(extents.x) * ceil(extents.y) * ceil(extents.z))
+    extents = ceildiv(stop - start, step)
+    return int(extents.x * extents.y * extents.z)
 
 def make_cubes(start, stop, step):
     """Produce the target cubes to downsample

--- a/activities/resolution_hierarchy.py
+++ b/activities/resolution_hierarchy.py
@@ -22,6 +22,7 @@ import types
 import json
 import time
 import random
+from math import ceil
 from multiprocessing import Pool, cpu_count
 from datetime import timedelta, datetime
 
@@ -284,7 +285,7 @@ def num_cubes(start, stop, step):
         int: The number of volumes in the frame
     """
     extents = (stop - start) / step
-    return int(extents.x * extents.y * extents.z)
+    return int(ceil(extents.x) * ceil(extents.y) * ceil(extents.z))
 
 def make_cubes(start, stop, step):
     """Produce the target cubes to downsample


### PR DESCRIPTION
Found a bug when creating jhuapl-boss/boss#18 that if the X, Y, or Z of the frame extent is smaller then the size of the volume being downsampled an incorrect count is calculated due to float values less than one being multiplied together.