### PR TITLE
Bug fix for running in non us-east-1 regions - to integration

### DIFF
--- a/lambdautils/deploy_lambdas.py
+++ b/lambdautils/deploy_lambdas.py
@@ -56,7 +56,10 @@ def upload_to_s3(session, zip_file, bucket):
     """
     key = os.path.basename(zip_file)
     s3 = session.client('s3')
-    s3.create_bucket(Bucket=bucket)
+    try:
+        s3.create_bucket(Bucket=bucket)
+    except s3.exceptions.BucketAlreadyOwnedByYou:
+        pass
     s3.put_object(Bucket=bucket, Key=key, Body=open(zip_file, 'rb'))
 
 


### PR DESCRIPTION
During the refactor of boss-manage I discovered that a call to `create_bucket()` has a different response in the `us-east-1` region if the bucket already exists and is owned by your account. In the `us-east-1` region there is no error but in any other region an exception is raised. This difference means that if a lambda is deployed to a bucket in any region besides `us-east-1` then the script will fail.

From AWS
```
The bucket you tried to create already exists, and you own it. Amazon S3 returns this error in all AWS 
Regions except us-east-1 (N. Virginia). For legacy compatibility, if you re-create an existing bucket that 
you already own in us-east-1, Amazon S3 returns 200 OK and resets the bucket access control lists (ACLs).
```