### PR TITLE
Added the firing of extra lambdas

### DIFF
--- a/activities/resolution_hierarchy.py
+++ b/activities/resolution_hierarchy.py
@@ -72,6 +72,10 @@ POOL_SIZE = int(cpu_count() * 2)
 # int: The number of status poll cycles that have a count of 0 (zero) before the
 #      polling loop exits
 ZERO_COUNT = 3
+
+# int: The number of extra lambdas to fire off each round
+EXTRA_LAMBDAS = 100
+
 ###########################################################
 
 class ResolutionHierarchyError(Exception):
@@ -213,7 +217,7 @@ def downsample_channel(args):
             cube_count = populate_cubes(cubes_arn, cubes_start, cubes_stop, step)
 
             log.debug("Invoking downsample lambdas")
-            lambda_count = ceildiv(cube_count, BUCKET_SIZE)
+            lambda_count = ceildiv(cube_count, BUCKET_SIZE) + EXTRA_LAMBDAS
             lambda_args = {
                 'bucket_size': BUCKET_SIZE,
                 'args': args,
@@ -461,7 +465,10 @@ def launch_lambdas(total_count, lambda_arn, lambda_args, dlq_arn, cubes_arn):
                         raise FailedLambdaError()
 
             if count_count == UNCHANGING_LAUNCH:
-                needed = ceildiv(count, BUCKET_SIZE)
+                # We have noticed that the last few messages are spread across multiple AWS queue servers and
+                # A single lambda requesting 10 messages will only get messages from a single queue server.  So we
+                # pad the number of lambdas by EXTRAS_LAMBDAS to avoid extra looping cycles.
+                needed = ceildiv(count, BUCKET_SIZE) + EXTRA_LAMBDAS
                 if needed > 0:
                     log.debug("Launching {} more lambdas".format(needed))
 
@@ -588,8 +595,8 @@ def check_queue(queue_arn):
                     body = json.loads(msg['Body'])
                     error = body['Records'][0]['Sns']['MessageAttributes']['ErrorMessage']['Value']
                     log.debug("DLQ Error: {}".format(error))
-            except:
-                log.exception("Problem gettting DLQ error message")
+            except Exception as err:
+                log.exception("Problem getting DLQ error message: {}".format(err))
         return message_count
 
 def lambda_throttle_count(lambda_arn):
@@ -628,6 +635,6 @@ def lambda_throttle_count(lambda_arn):
             if 'SampleCount' in resp['Datapoints'][0]:
                 return resp['Datapoints'][0]['SampleCount']
         return 0.0
-    except:
-        log.exception("Problem getting Lambda Throttle Count")
+    except Exception as err:
+        log.exception("Problem getting Lambda Throttle Count: {}".format(err))
         return -1

--- a/activities/resolution_hierarchy.py
+++ b/activities/resolution_hierarchy.py
@@ -468,12 +468,12 @@ def launch_lambdas(total_count, lambda_arn, lambda_args, dlq_arn, cubes_arn):
                 # We have noticed that the last few messages are spread across multiple AWS queue servers and
                 # A single lambda requesting 10 messages will only get messages from a single queue server.  So we
                 # pad the number of lambdas by EXTRAS_LAMBDAS to avoid extra looping cycles.
-                needed = ceildiv(count, BUCKET_SIZE) + EXTRA_LAMBDAS
+                needed = ceildiv(count, BUCKET_SIZE)
                 if needed > 0:
                     log.debug("Launching {} more lambdas".format(needed))
 
                     start = datetime.now()
-                    invoke_lambdas(needed, lambda_arn, lambda_args, dlq_arn)
+                    invoke_lambdas(needed + EXTRA_LAMBDAS, lambda_arn, lambda_args, dlq_arn)
                     stop = datetime.now()
                     log.debug("Launched {} lambdas in {}".format(needed, stop - start))
         else:


### PR DESCRIPTION
The purpose of this PR is two fold.  
1) When we calculate the number of lambdas that need to fire each round it often does not fire enough actual lambdas.  This is because each lambda only requests messages from a single SQS server.  Since not all servers know about all the messages this can cause the system sleep when a small number of messages are still waiting to be grabbed on the queue.  It can actually slow down each round by 2 - 8 minutes of time.  
2) Added prints strings to two exceptions that shouldn't occur, but if they do it will nice to see the error messages that occurred.