### PR TITLE
Tile uploaded lambda update

### DIFF
--- a/lambda/tile_ingest_lambda.py
+++ b/lambda/tile_ingest_lambda.py
@@ -68,8 +68,9 @@ def handler(event, context):
             time.sleep(1)
 
     if not msg_id:
-        # No tiles ready to ingest. Exit.
-        sys.exit("No ingest message available")
+        # No tiles ready to ingest.
+        print("No ingest message available")
+        return
 
     # Get the chunk key of the tiles to ingest.
     chunk_key = msg_data['chunk_key']
@@ -142,7 +143,8 @@ def handler(event, context):
                 tile_key))
             # Remove message so it's not redelivered.
             ingest_queue.deleteMessage(msg_id, msg_rx_handle)
-            sys.exit("Aborting due to missing tile in bucket")
+            print("Aborting due to missing tile in bucket")
+            return
 
         image_bytes = BytesIO(image_data)
         image_size = image_bytes.getbuffer().nbytes

--- a/lambda/tile_ingest_lambda.py
+++ b/lambda/tile_ingest_lambda.py
@@ -85,9 +85,11 @@ def handler(event, context):
     # tile_index_result (dict): keys are S3 object keys of the tiles comprising the chunk.
     tile_index_result = tile_index_db.getCuboid(msg_data["chunk_key"], int(msg_data["ingest_job"]))
     if tile_index_result is None:
+        # If chunk_key is gone, another lambda uploaded the cuboids and deleted the chunk_key afterwards.
         # Remove message so it's not redelivered.
         ingest_queue.deleteMessage(msg_id, msg_rx_handle)
-        sys.exit("Aborting due to chunk key missing from tile index table")
+        print("Aborting due to chunk key missing from tile index table")
+        return
 
     # Sort the tile keys
     print("Tile Keys: {}".format(tile_index_result["tile_uploaded_map"]))

--- a/lambda/tile_uploaded_lambda.py
+++ b/lambda/tile_uploaded_lambda.py
@@ -65,6 +65,9 @@ def handler(event, context):
     tile_index_db = BossTileIndexDB(proj_info.project_name)
     chunk = tile_index_db.getCuboid(metadata["chunk_key"], int(metadata["ingest_job"]))
     if chunk:
+        if tile_index_db.cuboidReady(metadata["chunk_key"], chunk["tile_uploaded_map"]):
+            print("Chunk {} already has all its tiles, aborting.".format(metadata["chunk_key"]))
+            return
         print("Updating tile index for chunk_key: {}".format(metadata["chunk_key"]))
         chunk_ready = tile_index_db.markTileAsUploaded(metadata["chunk_key"], tile_key, int(metadata["ingest_job"]))
     else:

--- a/lambda/tile_uploaded_lambda.py
+++ b/lambda/tile_uploaded_lambda.py
@@ -66,7 +66,7 @@ def handler(event, context):
     chunk = tile_index_db.getCuboid(metadata["chunk_key"], int(metadata["ingest_job"]))
     if chunk:
         if tile_index_db.cuboidReady(metadata["chunk_key"], chunk["tile_uploaded_map"]):
-            print("Chunk {} already has all its tiles, aborting.".format(metadata["chunk_key"]))
+            print("Chunk already has all its tiles, aborting for: {}".format(metadata["chunk_key"]))
             return
         print("Updating tile index for chunk_key: {}".format(metadata["chunk_key"]))
         chunk_ready = tile_index_db.markTileAsUploaded(metadata["chunk_key"], tile_key, int(metadata["ingest_job"]))


### PR DESCRIPTION
Upload lambda now checks that 16 tiles are not already uploaded adding a tile in DynamnoDb to the chunk_key and possibly firing off a 2nd ingest_lambda.
Removed sys.exit and converted it to return. sys.exit causes lambda to return an error.  Now that this code is not used in multilambda we don't need the sys.exit anymore.