### PR TITLE
Let ingest lambda fire when 16 tiles already there.

### DIFF
--- a/lambda/tile_uploaded_lambda.py
+++ b/lambda/tile_uploaded_lambda.py
@@ -66,12 +66,13 @@ def handler(event, context):
     chunk = tile_index_db.getCuboid(metadata["chunk_key"], int(metadata["ingest_job"]))
     if chunk:
         if tile_index_db.cuboidReady(metadata["chunk_key"], chunk["tile_uploaded_map"]):
-            print("Chunk already has all its tiles, aborting for: {}".format(metadata["chunk_key"]))
-            upload_queue = UploadQueue(proj_info)
-            upload_queue.deleteMessage(message_id, receipt_handle)
-            return
-        print("Updating tile index for chunk_key: {}".format(metadata["chunk_key"]))
-        chunk_ready = tile_index_db.markTileAsUploaded(metadata["chunk_key"], tile_key, int(metadata["ingest_job"]))
+            print("Chunk already has all its tiles: {}".format(metadata["chunk_key"]))
+            # Go ahead and setup to fire another ingest lambda so this tile
+            # entry will be deleted on successful execution of the ingest lambda.
+            chunk_ready = True
+        else:
+            print("Updating tile index for chunk_key: {}".format(metadata["chunk_key"]))
+            chunk_ready = tile_index_db.markTileAsUploaded(metadata["chunk_key"], tile_key, int(metadata["ingest_job"]))
     else:
         # First tile in the chunk
         print("Creating first entry for chunk_key: {}".format(metadata["chunk_key"]))


### PR DESCRIPTION
Observed many tile entries still present that had all 16 tiles in their
maps, but none of their cuboids were in the cuboid bucket.  Must allow
the tile ingest lambda to refire to get these cuboids in.

Already put into production, but for posterity . . .

Related PR:
https://github.com/jhuapl-boss/boss-manage/pull/32
