### PR TITLE
Allow triggering of ingest lambda direct from SQS.

### DIFF
--- a/lambda/tile_ingest_lambda.py
+++ b/lambda/tile_ingest_lambda.py
@@ -117,7 +117,8 @@ def handler(event, context):
     tile_key_list = [x.rsplit("&", 2) for x in tile_index_result["tile_uploaded_map"].keys()]
     if len(tile_key_list) < tiles_in_chunk:
         print("Not a full set of 16 tiles. Assuming it has handled already, tiles: {}".format(len(tile_key_list)))
-        ingest_queue.deleteMessage(msg_id, msg_rx_handle)
+        if not sqs_triggered:
+            ingest_queue.deleteMessage(msg_id, msg_rx_handle)
         return
     tile_key_list = sorted(tile_key_list, key=lambda x: int(x[1]))
     tile_key_list = ["&".join(x) for x in tile_key_list]

--- a/lambda/tile_ingest_lambda.py
+++ b/lambda/tile_ingest_lambda.py
@@ -92,6 +92,7 @@ def handler(event, context):
 
 
     print("Ingesting Chunk {}".format(chunk_key))
+    tiles_in_chunk = chunk_key.split('&')[1]
 
     # Setup SPDB instance
     sp = SpatialDB(msg_data['parameters']["KVIO_SETTINGS"],
@@ -114,7 +115,7 @@ def handler(event, context):
     # Sort the tile keys
     print("Tile Keys: {}".format(tile_index_result["tile_uploaded_map"]))
     tile_key_list = [x.rsplit("&", 2) for x in tile_index_result["tile_uploaded_map"].keys()]
-    if len(tile_key_list) < 16:
+    if len(tile_key_list) < tiles_in_chunk:
         print("Not a full set of 16 tiles. Assuming it has handled already, tiles: {}".format(len(tile_key_list)))
         ingest_queue.deleteMessage(msg_id, msg_rx_handle)
         return

--- a/lambda/tile_ingest_lambda.py
+++ b/lambda/tile_ingest_lambda.py
@@ -48,7 +48,7 @@ def handler(event, context):
 
     if sqs_triggered :
         # Lambda invoked by an SQS trigger.
-        msg_data = json.loads(event['Records'][0].body)
+        msg_data = json.loads(event['Records'][0]['body'])
         # Load the project info from the chunk key you are processing
         chunk_key = msg_data['chunk_key']
         proj_info = BossIngestProj.fromSupercuboidKey(chunk_key)

--- a/lambda/tile_ingest_lambda.py
+++ b/lambda/tile_ingest_lambda.py
@@ -44,11 +44,10 @@ def handler(event, context):
 
     # Used as a guard against trying to delete the SQS message when lambda is
     # triggered by SQS.
-    sqs_triggered = False
+    sqs_triggered = 'Records' in event and len(event['Records']) > 0
 
-    if 'Records' in event and len(event['Records']) > 0:
+    if sqs_triggered :
         # Lambda invoked by an SQS trigger.
-        sqs_triggered = True
         msg_data = json.loads(event['Records'][0].body)
         # Load the project info from the chunk key you are processing
         chunk_key = msg_data['chunk_key']

--- a/lambda/tile_ingest_lambda.py
+++ b/lambda/tile_ingest_lambda.py
@@ -92,7 +92,7 @@ def handler(event, context):
 
 
     print("Ingesting Chunk {}".format(chunk_key))
-    tiles_in_chunk = chunk_key.split('&')[1]
+    tiles_in_chunk = int(chunk_key.split('&')[1])
 
     # Setup SPDB instance
     sp = SpatialDB(msg_data['parameters']["KVIO_SETTINGS"],


### PR DESCRIPTION
Ugly code, but didn't want to do a full refactor.

This will let us connect a large ingest queue directly to the tile ingest lambda so AWS can manage draining of the queue.

Not tested yet.