### PR TITLE
Fixed ingest_queue_populate to handle a result array with Nones included

### DIFF
--- a/activities/ingest_queue_populate.py
+++ b/activities/ingest_queue_populate.py
@@ -87,7 +87,7 @@ def ingest_populate(args):
                      rampup_backoff=RAMPUP_BACKOFF,
                      poll_delay=POLL_DELAY,
                      status_delay=STATUS_DELAY)
-    messages_uploaded = sum(results)
+    messages_uploaded = sum_with_nones(results)
 
     if args["ingest_type"] == 0:
         tile_count = get_tile_count(args)
@@ -115,6 +115,24 @@ def ingest_populate(args):
         }
 
 
+def sum_with_nones(arr):
+    """
+    Totals up the arr, array can have ints or Nones.
+    Args:
+        arr[int|None]:
+
+    Returns: total of ints in arr
+
+    """
+    total = 0
+    if arr is None:
+        return 0;
+    for i in arr:
+        if i is None:
+            continue
+        else:
+            total += i
+    return total
 
 
 

--- a/activities/ingest_queue_populate.py
+++ b/activities/ingest_queue_populate.py
@@ -87,7 +87,11 @@ def ingest_populate(args):
                      rampup_backoff=RAMPUP_BACKOFF,
                      poll_delay=POLL_DELAY,
                      status_delay=STATUS_DELAY)
-    messages_uploaded = sum_with_nones(results)
+
+    if results is None:
+        messages_uploaded = 0
+    else:
+        messages_uploaded = sum(filter(None, results))
 
     if args["ingest_type"] == 0:
         tile_count = get_tile_count(args)
@@ -113,27 +117,6 @@ def ingest_populate(args):
             'arn': args['upload_queue'],
             'count': vol_count,
         }
-
-
-def sum_with_nones(arr):
-    """
-    Totals up the arr, array can have ints or Nones.
-    Args:
-        arr[int|None]:
-
-    Returns: total of ints in arr
-
-    """
-    total = 0
-    if arr is None:
-        return 0;
-    for i in arr:
-        if i is None:
-            continue
-        else:
-            total += i
-    return total
-
 
 
 def clear_queue(arn):

--- a/activities/ingest_queue_populate.py
+++ b/activities/ingest_queue_populate.py
@@ -88,6 +88,7 @@ def ingest_populate(args):
                      poll_delay=POLL_DELAY,
                      status_delay=STATUS_DELAY)
 
+    # At least one None values in the return of fanout. This avoids an exception in those cases.
     if results is None:
         messages_uploaded = 0
     else:


### PR DESCRIPTION
We are seeing an error where the results of heaviside fanout have Nones included along with the values.  Updating the sum(arr)  with a new function that ignores None values.  