### PR TITLE
update new activities with the new way bossLogger works

### DIFF
--- a/activities/boss_db.py
+++ b/activities/boss_db.py
@@ -15,7 +15,7 @@
 import pymysql.cursors
 import bossutils
 
-LOG = bossutils.logger.BossLogger().logger
+LOG = bossutils.logger.bossLogger()
 
 def get_db_connection(host):
     """

--- a/activities/cleanup_ingest.py
+++ b/activities/cleanup_ingest.py
@@ -38,7 +38,7 @@ Assumptions:
 
 # Hook up Boss exception handler.
 set_excepthook()
-log = logger.BossLogger().logger
+log = logger.bossLogger()
 
 # Accepted status values to IngestCleaner.
 COMPLETE_STATUS = 'complete'

--- a/activities/scan_for_missing_chunks.py
+++ b/activities/scan_for_missing_chunks.py
@@ -28,7 +28,7 @@ tiles are missing, they are placed back in the upload queue for that ingest
 job.  If there are missing tiles, the ingest job's state is reset to UPLOADING.
 """
 
-log = logger.BossLogger().logger
+log = logger.bossLogger()
 
 # Tile index attributes defined in ndingest.git/nddynamo/schemas/boss_tile_index.json.
 APPENDED_TASK_ID = 'appended_task_id'


### PR DESCRIPTION
Changed new activities to use the new way bossLogger() is created.

log = bossutils.logger.bossLogger()
