### PR TITLE
Ubuntu 20.04

### DIFF
--- a/cachemgr/boss_cachemissd.py
+++ b/cachemgr/boss_cachemissd.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/python3
 
 # Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
 #

--- a/cachemgr/boss_deadletterd.py
+++ b/cachemgr/boss_deadletterd.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/python3
 
 # Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
 #

--- a/cachemgr/boss_delayedwrited.py
+++ b/cachemgr/boss_delayedwrited.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/python3
 
 # Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
 #

--- a/cachemgr/boss_prefetchd.py
+++ b/cachemgr/boss_prefetchd.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/python3
 
 # Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
 #

--- a/cachemgr/boss_sqs_watcherd.py
+++ b/cachemgr/boss_sqs_watcherd.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/python3
 
 # Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
 #


### PR DESCRIPTION
Updates Python path for scripts running on Ubuntu 20.04 servers.

Ubuntu 20.04 includes a system Python 3.8 in `/usr/bin`. The previous path used by these scripts was `/usr/local/bin`.

PR includes https://github.com/jhuapl-boss/boss-tools/pull/37 (Django 2.x upgrade/Provide way to use Keycloak w/o Vault).

## Related PRs:
https://github.com/jhuapl-boss/boss-manage/pull/86
https://github.com/jhuapl-boss/boss/pull/53