### PR TITLE
Make lambda also usable when triggered by SQS.

### DIFF
--- a/lambda/start_sfn_lambda.py
+++ b/lambda/start_sfn_lambda.py
@@ -1,38 +1,87 @@
-# Lambda for starting step functions from within another step function.
-# Step function tasks should catch KeyError and abort instead of retrying
-# because the lambda will never succeed if a KeyError is raised.
+# Copyright 2021 The Johns Hopkins University Applied Physics Laboratory
 #
-# Inputs:
-# {
-#   "sfn_arn": "..."
-# }
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Outputs (all inputs with the following additions):
-# {
-#   "sfn_output": {
-#     "executionArn": "...",
-#     "startDate": "..."
-#   }
-# }
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Lambda for starting step functions from within another step function OR
+via from an SQS message when the lambda is connected to an SQS queue.
+Step function tasks should catch KeyError and abort instead of retrying
+because the lambda will never succeed if a KeyError is raised.
+
+See the AWS documentation for a full example of what the event data looks like
+from an SQS queue: https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+
+Inputs:
+{
+  "sfn_arn": "..."
+  # OR
+  "Records": [{ ...
+                body: "{\"sfn_arn\": \"the sfn ARN\" ... }"
+              }
+             ]
+}
+
+Outputs (when invoked by a step function, all inputs with the following
+additions; no output when invoked by SQS):
+{
+  "sfn_output": {
+    "executionArn": "...",
+    "startDate": "..."
+  }
+}
+"""
 
 import boto3
 import json
 
 
 def handler(event, context):
-    sfn = boto3.client('stepfunctions')
-    
-    resp = sfn.start_execution(
-        stateMachineArn=event['sfn_arn'],
-        input=json.dumps(event)
-    )
+    if "Records" in event and len(event["Records"]) > 0:
+        if "body" not in event["Records"][0]:
+            raise KeyError("No body found in SQS message")
+        body = json.loads(event["Records"][0]["body"])
+        if "sfn_arn" not in body:
+            raise KeyError("SQS message does not contain 'sfn_arn'")
+        run_from_sfn(body["sfn_arn"], body)
+        return
 
-    start_date = resp.pop('startDate', None)
+    if "sfn_arn" in event:
+        resp = run_from_sfn(event["sfn_arn"], event)
+        event["sfn_output"] = resp
+        return event
+
+    raise KeyError("event must contain 'sfn_arn' or 'Records[0]'")
+
+
+def run_from_sfn(arn, sfn_args):
+    """
+    Start the step function.
+
+    Args:
+        arn (str): step function ARN.
+        sfn_args (dict): Arguments passed to step function.
+
+    Returns:
+        (dict): Response from boto3 start_execution() + 'startDate'.
+    """
+    sfn = boto3.client("stepfunctions")
+
+    resp = sfn.start_execution(stateMachineArn=arn, input=json.dumps(sfn_args))
+
+    start_date = resp.pop("startDate", None)
     if start_date is not None:
         # Make this JSON serializable.
-        resp['startDate'] = str(start_date)
+        resp["startDate"] = str(start_date)
 
-    event['sfn_output'] = resp
-
-    return event
-
+    return resp

--- a/lambdafcns/start_sfn_lambda.py
+++ b/lambdafcns/start_sfn_lambda.py
@@ -1,0 +1,1 @@
+../lambda/start_sfn_lambda.py

--- a/lmbdtest/test_start_sfn_lambda.py
+++ b/lmbdtest/test_start_sfn_lambda.py
@@ -1,0 +1,57 @@
+# Copyright 2021 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+from unittest.mock import call, patch
+from copy import deepcopy
+
+# lambdafcns contains symbolic links to lambda functions in boss-tools/lambda.
+# Since lambda is a reserved word, this allows importing from that folder
+# without updating scripts responsible for deploying the lambda code.
+from lambdafcns.start_sfn_lambda import handler
+
+
+class TestStartSfnLambda(unittest.TestCase):
+    def test_missing_required_args(self):
+        with self.assertRaises(KeyError):
+            handler({"foo": "bar"}, None)
+
+    def test_invoke_from_sfn(self):
+        """Test the lambda as it would work when run as a step function state."""
+        with patch(
+            "lambdafcns.start_sfn_lambda.run_from_sfn", autospec=True
+        ) as fake_run_from_sfn:
+            event = {"sfn_arn": "fake_arn", "foo": "bar"}
+            fake_resp = {"startDate": "now"}
+            exp = deepcopy(event)
+            exp["sfn_output"] = fake_resp
+            fake_run_from_sfn.return_value = fake_resp
+
+            actual = handler(event, None)
+            self.assertEqual(exp, actual)
+
+    def test_invoke_from_sqs(self):
+        """Test the lambda as it would work when triggered via SQS."""
+        with patch(
+            "lambdafcns.start_sfn_lambda.run_from_sfn", autospec=True
+        ) as fake_run_from_sfn:
+            body = {"sfn_arn": "some_fake_arn", "foo": "bar"}
+            event = {"Records": [{"body": json.dumps(body)}]}
+
+            # No return value when triggered via SQS.
+            handler(event, None)
+            self.assertEqual(
+                [call(body["sfn_arn"], body)], fake_run_from_sfn.mock_calls
+            )


### PR DESCRIPTION
Previously this lambda was only used as a state of a step function.
Now it also works when an SQS queue is connected as an event source.

Added unit test to test both means of execution.

Formatted with Black.