### PR TITLE
Fix cutout_to_black Delayed Write Issue

### DIFF
--- a/lambda/s3_flush_lambda.py
+++ b/lambda/s3_flush_lambda.py
@@ -92,12 +92,6 @@ while run_cnt < 2:
         # Create resource instance
         resource = BossResourceBasic()
         resource.from_dict(flush_msg_data["resource"])
-
-        # Check if cuboid is black overwrite
-        try:
-            to_black = flush_msg_data["to_black"]
-        except KeyError:
-            to_black = False
     else:
         # Nothing to flush. Exit.
         print("No flush message available")
@@ -118,6 +112,10 @@ while run_cnt < 2:
     cube_dim = CUBOIDSIZE[resolution]
     time_sample = int(parts.time_sample)
     morton = int(parts.morton_id)
+
+    # check if its a cutout_to_black cuboid
+    to_black = "BLACK" in write_cuboid_key
+
     write_cuboid_keys_to_remove = [write_cuboid_key]
 
     if exist_keys:  # Cuboid Exists
@@ -179,6 +177,8 @@ while run_cnt < 2:
             print("Delayed Write: {}".format(key))
             # Track what keys have been flushed
             write_cuboid_keys_to_remove.append(key)
+            # Check if its a cutout_to_black cuboid
+            to_black = "BLACK" in key
             # Get the data from the buffer
             write_cuboid_bytes = sp.kvio.get_cube_from_write_buffer(key)
             new_cube = Cube.create_cube(resource, cube_dim)


### PR DESCRIPTION
As discovered from integration tests on boss (see PR jhuapl-boss/boss#66) there was an issue where delayed writes would not be processed as a cutout_to_black request. I fixed this by instead having the to_black flag be part of the write_cuboid_key instead of part of the SQS message.

See PR for boss: jhuapl-boss/boss#66
See PR for spdb: jhuapl-boss/spdb#24

With the changes from spdb, I had to change the s3_flush lambda to recognize the new `to_black` flag. 

How it worked before:

1. Once a message was received by the lambda, the `is_black` boolean variable would be accessed from the message content to see if its a cutout_to_black request.
2. If it is, the overwrite_to_black method is called on the cuboid. 

This path didn't work for delayed writes. So the new way:

1. Message is received by lambda.
2. Lambda checks if write key has "BLACK" prefix. 
3. If it does, the overwrite_to_black method is called on the cuboid. 

This method passed integration and unit testing for spdb and django. Please be very critical though! I am messing with write cuboid keys here which are part of the core design of the system. 