### PR TITLE
Revert "Downsample fix"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
-.vscode
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/lambda/downsample_volume.py
+++ b/lambda/downsample_volume.py
@@ -5,7 +5,7 @@ import blosc
 import boto3
 import hashlib
 import numpy as np
-import cv2
+from PIL import Image
 from spdb.c_lib.ndtype import CUBOIDSIZE
 from spdb.c_lib import ndlib
 from spdb.spatialdb import AWSObjectStore
@@ -295,7 +295,14 @@ def downsample_cube(volume, cube, is_annotation):
         for z in range(cube.dim.z):
             # DP NOTE: For isotropic downsample this skips Z slices, instead of trying to merge them
             slice = volume[z * volume.cubes.z, :, :]
-            cube[z, :, :] = cv2.resize(slice, (cube.shape.x, cube.shape.y), interpolation=cv2.INTER_LINEAR)
+            image = Image.frombuffer(image_type,
+                                     (volume.shape.x, volume.shape.y),
+                                     slice.flatten(),
+                                     'raw',
+                                     image_type,
+                                     0, 1)
+
+            cube[z, :, :] = Buffer.asarray(image.resize((cube.shape.x, cube.shape.y), Image.BILINEAR))
 
 def handler(args, context):
     def convert(args_, key):

--- a/lmbdtest/test_downsample_volume_lambda.py
+++ b/lmbdtest/test_downsample_volume_lambda.py
@@ -40,7 +40,7 @@ args = {
         'experiment_id': 1,
         'channel_id': 1,
         'annotation_channel': False,
-        'data_type': 'uint16',
+        'data_type': 'uint8',
 
         's3_bucket': 's3_bucket',
         's3_index': 's3_index',
@@ -155,7 +155,7 @@ class TestDownsampleVolumeLambda(unittest.TestCase):
         s3.create_bucket(Bucket = 's3_bucket')
 
         # Create cube of data
-        data = np.zeros([16,512,512], dtype=np.uint16, order='C')
+        data = np.zeros([16,512,512], dtype=np.uint8, order='C')
         data = blosc.compress(data, typesize=8)
 
         # Put cube data for the target cubes


### PR DESCRIPTION
Reverts jhuapl-boss/boss-tools#44
Since cv added 77MB to the lambda it is too large to build. Reverting this change until we figure out a way forward.

https://github.com/jhuapl-boss/spdb/pull/26