### PR TITLE
Update write id index lambda

### DIFF
--- a/lambda/start_sfn_lambda.py
+++ b/lambda/start_sfn_lambda.py
@@ -53,18 +53,18 @@ def handler(event, context):
         body = json.loads(event["Records"][0]["body"])
         if "sfn_arn" not in body:
             raise KeyError("SQS message does not contain 'sfn_arn'")
-        run_from_sfn(body["sfn_arn"], body)
+        start_sfn(body["sfn_arn"], body)
         return
 
     if "sfn_arn" in event:
-        resp = run_from_sfn(event["sfn_arn"], event)
+        resp = start_sfn(event["sfn_arn"], event)
         event["sfn_output"] = resp
         return event
 
     raise KeyError("event must contain 'sfn_arn' or 'Records[0]'")
 
 
-def run_from_sfn(arn, sfn_args):
+def start_sfn(arn, sfn_args):
     """
     Start the step function.
 

--- a/lambda/write_id_index_lambda.py
+++ b/lambda/write_id_index_lambda.py
@@ -83,11 +83,15 @@ def handler(event, context):
         s3_index_table, id_index_table, id_count_table, cuboid_bucket, 
         get_region())
 
+    # Track which ids successfully updated.
+    done_ids = set()
+
     try:
         for obj_id in event['id_group']:
             obj_ind.write_id_index(
                 id_index_new_chunk_threshold, 
                 event['cuboid_object_key'], obj_id, event['version'])
+            done_ids.add(obj_id)
         write_id_index_status['done'] = True
     except botocore.exceptions.ClientError as ex:
         # Probably had a throttle or a ConditionCheckFailed.
@@ -99,6 +103,8 @@ def handler(event, context):
             raise DynamoClientError(msg) from ex
         event['result'] = str(ex)
         prep_for_retry(write_id_index_status)
+
+    event['id_group'] = [i for i in event['id_group'] if i not in done_ids]
 
     return event
 

--- a/lambda/write_id_index_lambda.py
+++ b/lambda/write_id_index_lambda.py
@@ -23,10 +23,8 @@
 
 import botocore
 from bossutils.aws import get_region
-import json
 import random
 from spdb.spatialdb.object_indices import ObjectIndices
-from time import sleep
 
 BASE_DELAY_TIME_SECS = 5
 

--- a/lmbdtest/test_start_sfn_lambda.py
+++ b/lmbdtest/test_start_sfn_lambda.py
@@ -31,13 +31,13 @@ class TestStartSfnLambda(unittest.TestCase):
     def test_invoke_from_sfn(self):
         """Test the lambda as it would work when run as a step function state."""
         with patch(
-            "lambdafcns.start_sfn_lambda.run_from_sfn", autospec=True
-        ) as fake_run_from_sfn:
+            "lambdafcns.start_sfn_lambda.start_sfn", autospec=True
+        ) as fake_start_sfn:
             event = {"sfn_arn": "fake_arn", "foo": "bar"}
             fake_resp = {"startDate": "now"}
             exp = deepcopy(event)
             exp["sfn_output"] = fake_resp
-            fake_run_from_sfn.return_value = fake_resp
+            fake_start_sfn.return_value = fake_resp
 
             actual = handler(event, None)
             self.assertEqual(exp, actual)
@@ -45,13 +45,13 @@ class TestStartSfnLambda(unittest.TestCase):
     def test_invoke_from_sqs(self):
         """Test the lambda as it would work when triggered via SQS."""
         with patch(
-            "lambdafcns.start_sfn_lambda.run_from_sfn", autospec=True
-        ) as fake_run_from_sfn:
+            "lambdafcns.start_sfn_lambda.start_sfn", autospec=True
+        ) as fake_start_sfn:
             body = {"sfn_arn": "some_fake_arn", "foo": "bar"}
             event = {"Records": [{"body": json.dumps(body)}]}
 
             # No return value when triggered via SQS.
             handler(event, None)
             self.assertEqual(
-                [call(body["sfn_arn"], body)], fake_run_from_sfn.mock_calls
+                [call(body["sfn_arn"], body)], fake_start_sfn.mock_calls
             )


### PR DESCRIPTION
Update write id index lambda so it only returns the ids that haven't been written on a failure.

Also update `start_sfn_lambda.py` so the lambda can be triggered from a step function and from an SQS message.
