### PR TITLE
Connect ingest queue to ingest lambda if not empty

### DIFF
--- a/activities/boss_db.py
+++ b/activities/boss_db.py
@@ -30,7 +30,6 @@ def get_db_connection(host):
         (pymysql.Connection) connection to DB
     """
     vault = bossutils.vault.Vault()
-    LOG.debug("get_db_connection(): made connection to Vault")
 
     # ------ get values from Vault -----------
     user = vault.read('secret/endpoint/django/db', 'user')

--- a/activities/scan_for_missing_chunks.py
+++ b/activities/scan_for_missing_chunks.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2021 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ SQS_RETRY_TIMEOUT = 15
 
 # These values are defined in boss.git/django/bossingest/models.py.
 UPLOADING_STATUS = 1
+WAIT_ON_QUEUES = 6
 TILE_INGEST = 0
 
 
@@ -93,11 +94,11 @@ class ChunkScanner:
     JOB_FIELDS = frozenset([
         'collection', 'experiment', 'channel',
         'task_id', 'resolution', 'z_chunk_size',
-        'upload_queue', 'ingest_queue'
+        'upload_queue', 'ingest_queue', 'ingest_type',
     ])
 
     def __init__(self, dynamo, sqs, tile_index_table, db_host, job, resource,
-                 x_size, y_size, kvio_settings, stateio_config, objectio_config):
+                 tile_x_size, tile_y_size, kvio_settings, stateio_config, objectio_config):
         """
         Args:
             dynamo (boto3.Dynamodb): Dynamo client.
@@ -114,8 +115,8 @@ class ChunkScanner:
                 upload_queue (str): Tile upload queue.
                 ingest_queue (str): Tile ingest queue.
             resource (dict): Boss resource data.
-            x_size (int): Tile size in x dimension.
-            y_size (int): Tile size in y dimension.
+            tile_x_size (int): Tile size in x dimension.
+            tile_y_size (int): Tile size in y dimension.
             kvio_settings: spdb settings.
             stateio_config: spdb settings.
             objectio_config: spdb settings.
@@ -126,13 +127,14 @@ class ChunkScanner:
         self.db_host = db_host
         self.job = job
         self.resource = resource
-        self.x_size = x_size
-        self.y_size = y_size
+        self.tile_x_size = tile_x_size
+        self.tile_y_size = tile_y_size
         self.kvio_settings = kvio_settings
         self.stateio_config = stateio_config
         self.objectio_config = objectio_config
 
         self.found_missing_tiles = False
+        self.reenqueued_chunks = False
 
         # Validate job parameter.
         for field in ChunkScanner.JOB_FIELDS:
@@ -154,12 +156,12 @@ class ChunkScanner:
         Tiles missing from chunks are put back in the tile upload queue.
 
         Returns:
-            (bool): True if missing tiles found.
+            (bool): True if missing tiles found or if chunks put back on the ingest queue.
         """
         for i in range(0, MAX_TASK_ID_SUFFIX):
             self.run_scan(i)
 
-        return self.found_missing_tiles
+        return self.found_missing_tiles or self.reenqueued_chunks
 
     def run_scan(self, partition_num):
         """
@@ -175,6 +177,7 @@ class ChunkScanner:
         the complete process.
 
         self.found_missing_tiles set to True if missing tiles found.
+        self.reenqueued_chunks set to True if chunks put back in ingest queue.
 
         Args:
             dynamo (boto3.Dynamodb): Dynamo client.
@@ -205,13 +208,18 @@ class ChunkScanner:
             for resp in resp_iter:
                 for item in resp['Items']:
                     missing_msgs = self.check_tiles(item[CHUNK_KEY]['S'], item[TILE_UPLOADED_MAP_KEY]['M'])
-                    no_missing_tiles = False
+                    no_missing_tiles = True
                     if self.enqueue_missing_tiles(upload_queue, missing_msgs):
                         self.found_missing_tiles = True
-                        no_missing_tiles = True
-                        self.set_uploading_status(db_connection)
+                        no_missing_tiles = False
+                        self.set_ingest_status(db_connection, UPLOADING_STATUS)
                     if no_missing_tiles:
+                        # This is a chunk with all its tiles, so put it back
+                        # in the ingest queue.
+                        self.reenqueued_chunks = True
                         self.enqueue_chunk(ingest_queue, item[CHUNK_KEY]['S'])
+            if not self.found_missing_tiles and self.reenqueued_chunks:
+                self.set_ingest_status(db_connection, WAIT_ON_QUEUES)
         finally:
             db_connection.close()
 
@@ -224,30 +232,32 @@ class ChunkScanner:
             queue (sqs.Queue): Ingest queue.
             chunk_key (str): Key identifying which chunk to re-ingest.
         """
+        log.info(f'Re-enqueuing chunk: {chunk_key}')
         raw_msg = {
             'chunk_key': chunk_key,
-            'ingest_job': self.job,
+            'ingest_job': self.job['task_id'],
             'parameters': {
                 'KVIO_SETTINGS': self.kvio_settings,
                 'STATEIO_CONFIG': self.stateio_config,
                 'OBJECTIO_CONFIG': self.objectio_config,
                 'resource': self.resource,
             },
-            'x_size': self.tile_size_x,
-            'y_size': self.tile_size_y,
+            'x_size': self.tile_x_size,
+            'y_size': self.tile_y_size,
         }
         queue.send_message(MessageBody=json.dumps(raw_msg))
 
 
-    def set_uploading_status(self, db_connection):
+    def set_ingest_status(self, db_connection, status):
         """
-        Set the status of the ingest job to UPLOADING.
+        Set the status of the ingest job to the given status.
 
         Args:
             db_connection (pymysql.Connection)
+            status (int): New ingest status.
         """
         sql = 'UPDATE ingest_job SET status = %(status)s WHERE id = %(job_id)s'
-        sql_args = dict(status=str(UPLOADING_STATUS), job_id=str(self.job['task_id']))
+        sql_args = dict(status=str(status), job_id=str(self.job['task_id']))
         try:
             with db_connection.cursor(pymysql.cursors.SSCursor) as cursor:
                 rows = cursor.execute(sql, sql_args)
@@ -295,6 +305,7 @@ class ChunkScanner:
                 'chunk_key': chunk_key,
                 'tile_key': tile_key
             }
+            log.info(f'Re-enqueuing tile: {tile_key} belonging to chunk: {chunk_key}')
 
             yield json.dumps(msg)
 

--- a/activities/tests/test_scan_for_missing_chunks.py
+++ b/activities/tests/test_scan_for_missing_chunks.py
@@ -22,9 +22,17 @@ import pymysql
 import pymysql.cursors
 
 class TestChunkScanner(unittest.TestCase):
+    def setUp(self):
+        self.dynamo = None
+        self.sqs = None
+        self.x_size = 1024
+        self.y_size = 1024
+        self.kvio_settings = {}
+        self.stateio_config = {}
+        self.objectio_config = {}
+        self.resource = {}
+
     def test_check_tiles(self):
-        dynamo = None
-        sqs = None
         table = 'foo'
         db_host = 'bar'
         job = {
@@ -66,7 +74,9 @@ class TestChunkScanner(unittest.TestCase):
             '4a1c5be8336960d75fb4c4366544a9d3&90&141&985&0&94&40&2140&0'
         ]
 
-        cs = ChunkScanner(dynamo, sqs, table, db_host, job)
+        cs = ChunkScanner(self.dynamo, self.sqs, table, db_host, job,
+                          self.resource, self.x_size, self.y_size,
+                          self.kvio_settings, self.stateio_config, self.objectio_config)
         backend = BossBackend(None)
         chunk_key = backend.encode_chunk_key(16, cs._get_project_info(), job['resolution'],
             chunk_x, chunk_y, chunk_z)
@@ -84,8 +94,6 @@ class TestChunkScanner(unittest.TestCase):
         self.assertCountEqual(exp, actual)
 
     def test_check_tiles_no_missing_tiles(self):
-        dynamo = None
-        sqs = None
         table = 'foo'
         db_host = 'bar'
         job = {
@@ -123,7 +131,9 @@ class TestChunkScanner(unittest.TestCase):
             'b8f59755d83f8501e387fb15329ee7ee&90&141&985&0&94&40&2143&0': {'N': '1'},
         }
 
-        cs = ChunkScanner(dynamo, sqs, table, db_host, job)
+        cs = ChunkScanner(self.dynamo, self.sqs, table, db_host, job,
+                          self.resource, self.x_size, self.y_size,
+                          self.kvio_settings, self.stateio_config, self.objectio_config)
         backend = BossBackend(None)
         chunk_key = backend.encode_chunk_key(16, cs._get_project_info(), job['resolution'],
             chunk_x, chunk_y, chunk_z)
@@ -134,8 +144,6 @@ class TestChunkScanner(unittest.TestCase):
             next(actual)
 
     def test_enqueue_missing_tiles_no_errors(self):
-        dynamo = None
-        sqs = None
         table = 'foo'
         db_host = 'bar'
         job = {
@@ -166,7 +174,9 @@ class TestChunkScanner(unittest.TestCase):
                 for i in range(SQS_BATCH_SIZE, num_msgs)])
         ]
 
-        cs = ChunkScanner(dynamo, sqs, table, db_host, job)
+        cs = ChunkScanner(self.dynamo, self.sqs, table, db_host, job,
+                          self.resource, self.x_size, self.y_size,
+                          self.kvio_settings, self.stateio_config, self.objectio_config)
         self.assertTrue(cs.enqueue_missing_tiles(queue, iter(msgs)))
 
         self.assertEqual(exp_calls, queue.send_messages.call_args_list)
@@ -174,8 +184,6 @@ class TestChunkScanner(unittest.TestCase):
     # Replace sleep so test runs fast.
     @patch('time.sleep', autospec=True)
     def test_enqueue_missing_tiles_with_retry(self, fake_sleep):
-        dynamo = None
-        sqs = None
         table = 'foo'
         db_host = 'bar'
         job = {
@@ -208,7 +216,9 @@ class TestChunkScanner(unittest.TestCase):
                 for i in range(SQS_BATCH_SIZE, num_msgs)])
         ]
 
-        cs = ChunkScanner(dynamo, sqs, table, db_host, job)
+        cs = ChunkScanner(self.dynamo, self.sqs, table, db_host, job,
+                          self.resource, self.x_size, self.y_size,
+                          self.kvio_settings, self.stateio_config, self.objectio_config)
         self.assertTrue(cs.enqueue_missing_tiles(queue, iter(msgs)))
 
         self.assertEqual(exp_calls, queue.send_messages.call_args_list)
@@ -216,8 +226,6 @@ class TestChunkScanner(unittest.TestCase):
     # Replace sleep so test runs fast.
     @patch('time.sleep', autospec=True)
     def test_enqueue_missing_tiles_with_errors(self, fake_sleep):
-        dynamo = None
-        sqs = None
         table = 'foo'
         db_host = 'bar'
         job = {
@@ -253,7 +261,9 @@ class TestChunkScanner(unittest.TestCase):
                 for i in range(SQS_BATCH_SIZE, num_msgs)])
         ]
 
-        cs = ChunkScanner(dynamo, sqs, table, db_host, job)
+        cs = ChunkScanner(self.dynamo, self.sqs, table, db_host, job,
+                          self.resource, self.x_size, self.y_size,
+                          self.kvio_settings, self.stateio_config, self.objectio_config)
         self.assertTrue(cs.enqueue_missing_tiles(queue, iter(msgs)))
 
         self.assertEqual(exp_calls, queue.send_messages.call_args_list)
@@ -262,8 +272,6 @@ class TestChunkScanner(unittest.TestCase):
     @patch('time.sleep', autospec=True)
     def test_enqueue_missing_tiles_no_msgs(self, fake_sleep):
         """Should return False and not enqueue any messages if not given any."""
-        dynamo = None
-        sqs = None
         table = 'foo'
         db_host = 'bar'
         job = {
@@ -281,7 +289,9 @@ class TestChunkScanner(unittest.TestCase):
 
         msgs = []
 
-        cs = ChunkScanner(dynamo, sqs, table, db_host, job)
+        cs = ChunkScanner(self.dynamo, self.sqs, table, db_host, job,
+                          self.resource, self.x_size, self.y_size,
+                          self.kvio_settings, self.stateio_config, self.objectio_config)
         self.assertFalse(cs.enqueue_missing_tiles(queue, iter(msgs)))
         queue.send_messages.assert_not_called()
 

--- a/activities/tests/test_scan_for_missing_chunks.py
+++ b/activities/tests/test_scan_for_missing_chunks.py
@@ -43,7 +43,8 @@ class TestChunkScanner(unittest.TestCase):
             'resolution': 0,
             'z_chunk_size': 16,
             'upload_queue': 'foo',
-            'ingest_queue': 'bar'
+            'ingest_queue': 'bar',
+            'ingest_type': TILE_INGEST,
         }
 
         chunk_x = 94
@@ -104,7 +105,8 @@ class TestChunkScanner(unittest.TestCase):
             'resolution': 0,
             'z_chunk_size': 16,
             'upload_queue': 'foo',
-            'ingest_queue': 'bar'
+            'ingest_queue': 'bar',
+            'ingest_type': TILE_INGEST,
         }
 
         chunk_x = 94
@@ -154,7 +156,8 @@ class TestChunkScanner(unittest.TestCase):
             'resolution': 0,
             'z_chunk_size': 16,
             'upload_queue': 'foo',
-            'ingest_queue': 'bar'
+            'ingest_queue': 'bar',
+            'ingest_type': TILE_INGEST,
         }
 
         queue = MagicMock()
@@ -194,7 +197,8 @@ class TestChunkScanner(unittest.TestCase):
             'resolution': 0,
             'z_chunk_size': 16,
             'upload_queue': 'foo',
-            'ingest_queue': 'bar'
+            'ingest_queue': 'bar',
+            'ingest_type': TILE_INGEST,
         }
 
         queue = MagicMock()
@@ -236,7 +240,8 @@ class TestChunkScanner(unittest.TestCase):
             'resolution': 0,
             'z_chunk_size': 16,
             'upload_queue': 'foo',
-            'ingest_queue': 'bar'
+            'ingest_queue': 'bar',
+            'ingest_type': TILE_INGEST,
         }
 
         queue = MagicMock()
@@ -282,7 +287,8 @@ class TestChunkScanner(unittest.TestCase):
             'resolution': 0,
             'z_chunk_size': 16,
             'upload_queue': 'foo',
-            'ingest_queue': 'bar'
+            'ingest_queue': 'bar',
+            'ingest_type': TILE_INGEST,
         }
 
         queue = MagicMock()
@@ -320,7 +326,8 @@ class TestChunkScanner(unittest.TestCase):
             'resolution': 0,
             'z_chunk_size': 16,
             'upload_queue': 'foo',
-            'ingest_queue': 'bar'
+            'ingest_queue': 'bar',
+            'ingest_type': TILE_INGEST,
         }
 
         user_insert = """

--- a/lambda/tile_ingest_lambda.py
+++ b/lambda/tile_ingest_lambda.py
@@ -32,7 +32,6 @@ from ndingest.util.bossutil import BossUtil
 from bossnames.names import AWSNames
 
 from io import BytesIO
-import json
 from PIL import Image
 import numpy as np
 import math
@@ -70,7 +69,8 @@ def handler(event, context):
             ingest_queue = IngestQueue(proj_info)
             try:
                 msg = [x for x in ingest_queue.receiveMessage()]
-            except StopIteration:
+            # StopIteration may be converted to a RunTimeError.
+            except (StopIteration, RuntimeError):
                 msg = None
 
             if msg:

--- a/lambda/tile_uploaded_lambda.py
+++ b/lambda/tile_uploaded_lambda.py
@@ -32,7 +32,6 @@ Expected contents of the SQS message
     'parameters': {
         "upload_queue": XX
         "ingest_queue": XX,
-        "ingest_lambda":XX,
         "KVIO_SETTINGS": XX,
         "STATEIO_CONFIG": XX,
         "OBJECTIO_CONFIG": XX


### PR DESCRIPTION
Updates to step function activities and lambdas that support ingest.

The ingest queue is connected as an event source to the ingest lambda if it's non-empty when a complete request is received.

During ingest completion, any chunks with all of their tiles present are placed back in the ingest queue.

### Related PRs:
https://github.com/jhuapl-boss/boss-manage/pull/99
https://github.com/jhuapl-boss/boss/pull/83
https://github.com/jhuapl-boss/ingest-client/pull/54
