### PR TITLE
Fix logging for the cache mgr daemons.

### DIFF
--- a/bossutils/daemon_base.py
+++ b/bossutils/daemon_base.py
@@ -53,6 +53,7 @@ class DaemonBase:
     """
     def __init__(self, pid_file_name, pid_dir="/var/run"):
         self.pid_file = os.path.join(pid_dir, pid_file_name)
+        bossutils.logger.configure()
         self.log = bossutils.logger.bossLogger()
         self.running = False
         self.pid = None


### PR DESCRIPTION
Update to logging library now requires call to `configure()`.