### PR TITLE
fixes bug related to tile ingest

### DIFF
--- a/lambda/tile_ingest_lambda.py
+++ b/lambda/tile_ingest_lambda.py
@@ -202,6 +202,8 @@ def handler(event, context):
             tile_img = np.zeros((tile_size_x, tile_size_y), dtype=dtype)
         else:
             try:
+                # DP NOTE: Issues when specifying dtype in the asarray function with Pillow ver 8.3.1. 
+                # Fixed by separating array instantiation and dtype assignment. 
                 tile_img = np.asarray(Image.open(image_bytes))
                 tile_img = tile_img.astype(dtype)
             except TypeError as te:

--- a/lambda/tile_ingest_lambda.py
+++ b/lambda/tile_ingest_lambda.py
@@ -202,7 +202,8 @@ def handler(event, context):
             tile_img = np.zeros((tile_size_x, tile_size_y), dtype=dtype)
         else:
             try:
-                tile_img = np.asarray(Image.open(image_bytes), dtype=dtype)
+                tile_img = np.asarray(Image.open(image_bytes))
+                tile_img = tile_img.astype(dtype)
             except TypeError as te:
                 print('TileError: Incomplete tile, using black instead (tile_size_in_bytes, tile_key): {}, {}'
                       .format(image_size, tile_key))


### PR DESCRIPTION
Previous integration tests were getting an error during tile ingests:

```
TileError: Incomplete tile, using black instead (tile_size_in_bytes, tile_key): TileError: Incomplete tile, using black instead 
```

The underlying error seemed to be an issue parsing the image bytes as an array and assigning it to the correct datatype:

```
error: __array__() takes 1 positional argument but 2 were given
```

This was fixed by specifying the datatype after the image data was converted into a numpy array. Tested on dev stack. 